### PR TITLE
Use @toggleTransitionDuration for @toggleHandleTransition.

### DIFF
--- a/themes/default/modules/checkbox.variables
+++ b/themes/default/modules/checkbox.variables
@@ -156,8 +156,8 @@
 @toggleHandleRadius: @circularRadius;
 @toggleHandleOffset: 0rem;
 @toggleHandleTransition:
-  background @sliderTransitionDuration @defaultEasing,
-  left @sliderTransitionDuration @defaultEasing
+  background @toggleTransitionDuration @defaultEasing,
+  left @toggleTransitionDuration @defaultEasing
 ;
 
 @toggleLaneBackground: @transparentBlack;


### PR DESCRIPTION
@toggleHandleTransition looks to be mistakenly defined using @sliderTransitionDuration instead of @toggleTransitionDuration. This PR fixes it to use @toggleHandleTransition.