### PR TITLE
Wrong path in generated LESS files

### DIFF
--- a/themes/default/globals/site.variables
+++ b/themes/default/globals/site.variables
@@ -380,7 +380,7 @@
 
 /* For source only. Modified in gulp for dist */
 @imagePath : '../../themes/default/assets/images';
-@fontPath  : '../../themes/default/assets/fonts';
+@fontPath  : '../../default/assets/fonts';
 
 /*-------------------
        Em Sizes


### PR DESCRIPTION
The resulting path for font files will be `.../themes/themes/...` if the `@fontPath` is not defined this way.
This goes for all the themes in `themes` if the `site.variables`'s `@fontPath` is pointing to the old path.

This can be a fix for [issue 41](https://github.com/Semantic-Org/Semantic-UI-LESS/issues/41)