### PR TITLE
[FIX] Basic background label definitions

### DIFF
--- a/definitions/elements/label.less
+++ b/definitions/elements/label.less
@@ -566,7 +566,7 @@ a.ui.red.label:hover{
 }
 /* Basic */
 .ui.basic.red.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @red !important;
   border-color: @red !important;
 }
@@ -602,7 +602,7 @@ a.ui.orange.label:hover{
 }
 /* Basic */
 .ui.basic.orange.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @orange !important;
   border-color: @orange !important;
 }
@@ -638,7 +638,7 @@ a.ui.yellow.label:hover{
 }
 /* Basic */
 .ui.basic.yellow.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @yellow !important;
   border-color: @yellow !important;
 }
@@ -674,7 +674,7 @@ a.ui.olive.label:hover{
 }
 /* Basic */
 .ui.basic.olive.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @olive !important;
   border-color: @olive !important;
 }
@@ -710,7 +710,7 @@ a.ui.green.label:hover{
 }
 /* Basic */
 .ui.basic.green.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @green !important;
   border-color: @green !important;
 }
@@ -746,7 +746,7 @@ a.ui.teal.label:hover{
 }
 /* Basic */
 .ui.basic.teal.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @teal !important;
   border-color: @teal !important;
 }
@@ -782,7 +782,7 @@ a.ui.blue.label:hover{
 }
 /* Basic */
 .ui.basic.blue.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @blue !important;
   border-color: @blue !important;
 }
@@ -818,7 +818,7 @@ a.ui.violet.label:hover{
 }
 /* Basic */
 .ui.basic.violet.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @violet !important;
   border-color: @violet !important;
 }
@@ -854,7 +854,7 @@ a.ui.purple.label:hover{
 }
 /* Basic */
 .ui.basic.purple.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @purple !important;
   border-color: @purple !important;
 }
@@ -890,7 +890,7 @@ a.ui.pink.label:hover{
 }
 /* Basic */
 .ui.basic.pink.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @pink !important;
   border-color: @pink !important;
 }
@@ -926,7 +926,7 @@ a.ui.brown.label:hover{
 }
 /* Basic */
 .ui.basic.brown.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @brown !important;
   border-color: @brown !important;
 }
@@ -962,7 +962,7 @@ a.ui.grey.label:hover{
 }
 /* Basic */
 .ui.basic.grey.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @grey !important;
   border-color: @grey !important;
 }
@@ -998,7 +998,7 @@ a.ui.black.label:hover{
 }
 /* Basic */
 .ui.basic.black.label {
-  background-color: @basicBackground !important;
+  background: @basicBackground !important;
   color: @black !important;
   border-color: @black !important;
 }


### PR DESCRIPTION
* The `@basicBackground` variable is set to `none @white`, which is meant to be used in the `background` CSS property of elements. Labels use the variable in `background-color` though, which creates an invalid rule. Switch to use `background` instead.