### PR TITLE
changing background rule in primary button

### DIFF
--- a/definitions/elements/button.less
+++ b/definitions/elements/button.less
@@ -3056,7 +3056,7 @@
 /*--- Standard ---*/
 .ui.primary.buttons .button,
 .ui.primary.button {
-  background-color: @primaryColor;
+  background: @primaryColor;
   color: @primaryTextColor;
   text-shadow: @primaryTextShadow;
   background-image: @coloredBackgroundImage;
@@ -3066,19 +3066,19 @@
 }
 .ui.primary.buttons .button:hover,
 .ui.primary.button:hover {
-  background-color: @primaryColorHover;
+  background: @primaryColorHover @primaryColor;
   color: @primaryTextColor;
   text-shadow: @primaryTextShadow;
 }
 .ui.primary.buttons .button:focus,
 .ui.primary.button:focus {
-  background-color: @primaryColorFocus;
+  background: @primaryColorFocus;
   color: @primaryTextColor;
   text-shadow: @primaryTextShadow;
 }
 .ui.primary.buttons .button:active,
 .ui.primary.button:active {
-  background-color: @primaryColorDown;
+  background: @primaryColorDown;
   color: @primaryTextColor;
   text-shadow: @primaryTextShadow;
 }
@@ -3086,7 +3086,7 @@
 .ui.primary.buttons .active.button:active,
 .ui.primary.active.button,
 .ui.primary.button .active.button:active {
-  background-color: @primaryColorActive;
+  background: @primaryColorActive;
   color: @primaryTextColor;
   text-shadow: @primaryTextShadow;
 }


### PR DESCRIPTION
Hi Semantic!

This PR changes the rule of the primary button hover properties. The main reason is to have the flexibility to choose between a background color or a background-image when you set up your overrides. 

for example, on the button.less we can only specify a color under the sites.variables
```less
@primaryColorHover: : saturate(darken(@primaryColor, 5), 10, relative);
```
this overrides the color under `button.less` 

```less
.ui.primary.buttons .button:hover,
.ui.primary.button:hover {
  background-color: @primaryColorHover;
  color: @primaryTextColor;
  text-shadow: @primaryTextShadow;
}
```
 this limits us to specify a color only but not a gradient. by changing the rules under `.ui.primary.buttons` to 
```less
.ui.primary.buttons .button:hover,
.ui.primary.button:hover {
  background: @primaryColorHover @primaryColor;
  color: @primaryTextColor;
  text-shadow: @primaryTextShadow;
}
```

we can pass a gradient -or anything we want to pass as a background- to `@primaryColorHover`
```less
@primaryColorHover : linear-gradient(to right, #5873a4 0%,#44a6bb 100%);
```
giving us more flexibility to customize the theme. thanks for the time to review this and for the hard work put into Semantic-UI